### PR TITLE
네트워크 통신 모듈 retrofit 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,4 +25,10 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+
+    //retrofit
+    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
+
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="mashup.kr.mapc">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/mashup/kr/mapc/api/Api.java
+++ b/app/src/main/java/mashup/kr/mapc/api/Api.java
@@ -1,0 +1,31 @@
+package mashup.kr.mapc.api;
+
+import com.google.gson.Gson;
+
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public final class Api {
+
+    private static final String SERVER_URL = "https://test.mashup.com/";
+    private static ApiService apiService;
+
+    public static ApiService getInstance() {
+        if (apiService == null) {
+
+            OkHttpClient.Builder builder = new OkHttpClient.Builder();
+
+            Retrofit retrofit = new Retrofit.Builder()
+                    .baseUrl(SERVER_URL)
+                    .addConverterFactory(GsonConverterFactory.create(new Gson()))
+                    .client(builder.build())
+                    .build();
+
+            apiService = retrofit.create(ApiService.class);
+        }
+        return apiService;
+    }
+
+
+}

--- a/app/src/main/java/mashup/kr/mapc/api/ApiService.java
+++ b/app/src/main/java/mashup/kr/mapc/api/ApiService.java
@@ -1,0 +1,11 @@
+package mashup.kr.mapc.api;
+
+import retrofit2.Response;
+import retrofit2.http.GET;
+
+public interface ApiService {
+
+    @GET("/test")
+    Response<Void> test();
+
+}


### PR DESCRIPTION
## 작업내용
retrofit을 추가하고, 그를 사용할 수 있는 Api모듈을 만들었습니다.

## 사용방법
새로운 Api가 추가되면 아래와같이 `ApiService` 인터페이스에 Api규격을 명세합니다!

```java
public interface ApiService {

    @GET("/test")
    Call<Response<Void>> test();

}
```

사용이 필요한곳에서는 아래처럼 쓸 수 있어요!

```java
void requestApi() {
        Api.getInstance().test().enqueue(new Callback<Response<Void>>() {
            @Override
            public void onResponse(Call<Response<Void>> call, Response<Response<Void>> response) {
                
            }

            @Override
            public void onFailure(Call<Response<Void>> call, Throwable t) {

            }
        });
}
```