### PR TITLE
#14 retrofit에 rxjava adapter 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,8 +33,11 @@ dependencies {
     //retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
 
     // RxAndroid
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.0'
+
+
 }

--- a/app/src/main/java/mashup/kr/mapc/api/Api.java
+++ b/app/src/main/java/mashup/kr/mapc/api/Api.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public final class Api {
@@ -19,6 +20,7 @@ public final class Api {
             Retrofit retrofit = new Retrofit.Builder()
                     .baseUrl(SERVER_URL)
                     .addConverterFactory(GsonConverterFactory.create(new Gson()))
+                    .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                     .client(builder.build())
                     .build();
 


### PR DESCRIPTION
#14 에서 논의된것처럼 네트워크통신에서 rx를 사용하기위해
retrofit에서 리턴타입을 rx로 바꿔주는 adapter 라이브러리를 추가하였습니다.

앞으로는 리턴타입에 `Observable` `Flowable` `Maybe` `Single` `Completable`사용 가능합니다.