### PR TITLE
#14 람다식 사용을 위해 java 1.8을 사용하도록 변경

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## 개요 
- rxJava를 사용하다보면 함수가 1개인 interface(함수형 인터페이스)를 자주사용하게됩니다. 함수형 인터페이스는 람다식으로 간략화될수 있어서 rxJava와 람다식은 궁합이 좋습니다.
- java 1.8부터 람다를 사용할수 있어 1.8로 올렸습니다.

## 사용방법
람다식을 사용하기 전
```java
        Completable.timer(SPLASH_DELAY, TimeUnit.MILLISECONDS)
                .subscribe(new Action() {
                    @Override
                    public void run() throws Exception {
                        startMainActivity();
                    }

```

람다식으로 함축된 후
```java
        Completable.timer(SPLASH_DELAY, TimeUnit.MILLISECONDS)
                .subscribe(() -> startMainActivity());
```
