### PR TITLE
key와 관련된 파일 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 *.apk
 *.ap_
 
+# Key file
+google-services.json
+keys.xml
+
 # Files for the ART/Dalvik VM
 *.dex
 


### PR DESCRIPTION
#25 에서 travis에 encrypt되어 추가되었지만,
gitignore에 추가되지않은 keys.xml을 추가하였습니다.