### PR TITLE
'전체' 페이지 레이아웃 추가

### DIFF
--- a/app/src/main/java/kr/mashup/mapc/ui/main/MainActivity.java
+++ b/app/src/main/java/kr/mashup/mapc/ui/main/MainActivity.java
@@ -19,6 +19,7 @@ public class MainActivity extends BaseActivity {
 
     private static final int[] TAB_IMAGES = {R.drawable.ic_course, R.drawable.ic_booking, R.drawable.ic_guide, R.drawable.ic_bus, R.drawable.ic_etc};
     private static final String[] TAB_TEXTS = {"코스", "예약", "가이드", "버스", "전체"};
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -31,6 +32,34 @@ public class MainActivity extends BaseActivity {
         viewPager.setOffscreenPageLimit(PAGER_SCREEN_OFFSET_LIMIT);
         ViewPagerAdapter viewPagerAdapter = new ViewPagerAdapter(getSupportFragmentManager());
         viewPager.setAdapter(viewPagerAdapter);
+        viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+
+            }
+
+            @Override
+            public void onPageSelected(int position) {
+                switch (position) {
+                    case 0:
+                    case 1:
+                    case 2:
+                    case 3:
+                        setStatusBarColor(Color.WHITE);
+                        break;
+                    case 4:
+                        setStatusBarColor(getColor(R.color.salmon));
+                        break;
+                    default:
+                        throw new RuntimeException("예상치 못한 position : " + position);
+                }
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {
+
+            }
+        });
 
         initTab();
     }

--- a/app/src/main/java/kr/mashup/mapc/ui/main/etc/EtcAdapter.java
+++ b/app/src/main/java/kr/mashup/mapc/ui/main/etc/EtcAdapter.java
@@ -1,0 +1,40 @@
+package kr.mashup.mapc.ui.main.etc;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import kr.mashup.mapc.R;
+
+public class EtcAdapter extends RecyclerView.Adapter<EtcViewHolder> {
+
+    private ArrayList<String> dataList = new ArrayList<>();
+
+    @NonNull
+    @Override
+    public EtcViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        return new EtcViewHolder(
+                LayoutInflater.from(parent.getContext())
+                        .inflate(R.layout.item_etc_simple, parent, false)
+        );
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull EtcViewHolder holder, int position) {
+        holder.setData(dataList.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return dataList.size();
+    }
+
+    public void addDatas(String[] datas) {
+        dataList.addAll(Arrays.asList(datas));
+        notifyItemInserted(datas.length);
+    }
+}

--- a/app/src/main/java/kr/mashup/mapc/ui/main/etc/EtcFragment.java
+++ b/app/src/main/java/kr/mashup/mapc/ui/main/etc/EtcFragment.java
@@ -4,6 +4,8 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +13,13 @@ import android.view.ViewGroup;
 import kr.mashup.mapc.R;
 
 public class EtcFragment extends Fragment {
+
+    private static final String[] items = {
+            "언어설정",
+            "공지사항",
+            "이벤트",
+            "고객센터"
+    };
 
     @Nullable
     @Override
@@ -21,6 +30,13 @@ public class EtcFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        EtcAdapter adapter = new EtcAdapter();
+        RecyclerView recyclerView = view.findViewById(R.id.recycler_view);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        recyclerView.setAdapter(adapter);
+
+        adapter.addDatas(items);
     }
 
     public static EtcFragment newInstance() {

--- a/app/src/main/java/kr/mashup/mapc/ui/main/etc/EtcViewHolder.java
+++ b/app/src/main/java/kr/mashup/mapc/ui/main/etc/EtcViewHolder.java
@@ -1,0 +1,18 @@
+package kr.mashup.mapc.ui.main.etc;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+import kr.mashup.mapc.R;
+
+public class EtcViewHolder extends RecyclerView.ViewHolder {
+
+    public EtcViewHolder(View itemView) {
+        super(itemView);
+    }
+
+    public void setData(String data) {
+        ((TextView) itemView.findViewById(R.id.content)).setText(data);
+    }
+}

--- a/app/src/main/res/layout/fragment_etc.xml
+++ b/app/src/main/res/layout/fragment_etc.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.main.course.CourseFragment">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_etc.xml
+++ b/app/src/main/res/layout/fragment_etc.xml
@@ -1,13 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.main.course.CourseFragment">
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="82dp"
+        android:background="@color/salmon"
+        android:gravity="bottom"
+        android:paddingBottom="18dp"
+        android:paddingEnd="23dp"
+        android:paddingStart="23dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="서울시티투어버스"
+            android:textColor="@color/white"
+            android:textSize="18dp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-</FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/item_etc_simple.xml
+++ b/app/src/main/res/layout/item_etc_simple.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:foreground="?attr/selectableItemBackground"
+    android:orientation="vertical"
+    android:paddingEnd="22dp"
+    android:paddingStart="22dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="18dp"
+        android:layout_marginTop="18dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingEnd="7dp"
+        android:paddingStart="7dp">
+
+        <TextView
+            android:id="@+id/content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/greyish_brown"
+            android:textSize="14dp"
+            tools:text="언어설정" />
+
+        <!-- FIXME : 디자인이 준비되지 않아 임시로 텍스트로 처리 -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=">" />
+
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#dddddd" />
+
+</LinearLayout>


### PR DESCRIPTION
## 개요
'전체' 페이지 레이아웃을 작업하였습니다.

## 작업내용
- '전체' 페이지 리스트 및 툴바를 추가하였습니다.
- 페이지가 바뀔때 '전체' 페이지는 붉은색이 자연스러워 '전체' 페이지에서는 붉은색으로 변경되게 하였습니다.
![42622644_1401320800002255_5252876252913598464_n](https://user-images.githubusercontent.com/5474864/46067078-ec707d00-c1b0-11e8-8807-64b20f6eddf3.jpg)

## 기타
- '>' 아이콘은 리소스가 준비되지 않아 텍스트로 임시 대체하였습니다.